### PR TITLE
Add rate limiter for OpenAI API call

### DIFF
--- a/TalkToPapers.ipynb
+++ b/TalkToPapers.ipynb
@@ -311,14 +311,37 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import datetime\n",
+        "import time\n",
+        "\n",
+        "last_time = datetime.datetime.now()\n",
+        "\n",
+        "def rate_limit(min_interval_seconds = 0.5):\n",
+        "    global last_time\n",
+        "    sleep = min_interval_seconds - (datetime.datetime.now() - last_time).total_seconds() \n",
+        "    if sleep > 0:\n",
+        "        time.sleep(sleep)\n",
+        "    last_time = datetime.datetime.now()"
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": 153,
       "metadata": {
         "id": "JSgBs0QVApeE"
       },
       "outputs": [],
       "source": [
+        "def get_embedding_with_ratelimit(x, engine):\n",
+        "    rate_limit()\n",
+        "    return get_embedding(x, engine=engine)\n",
+        "\n",
         "embedding_model = \"text-embedding-ada-002\"\n",
-        "embeddings = df.text.apply([lambda x: get_embedding(x, engine=embedding_model)])\n",
+        "embeddings = df.text.apply([lambda x: get_embedding_with_ratelimit(x, engine=embedding_model)])\n",
         "df[\"embeddings\"] = embeddings"
       ]
     },


### PR DESCRIPTION
Added a `rate_limit` function that can be used with OpenAI API calls to prevent "Rate Limit Reached" error.
